### PR TITLE
Refine the exception hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,22 +281,36 @@ The library also decreases the risk of unexpected null values because parameters
 
 ### Error Handling
 
-When a parameter is required but not found, the library will throw an exception. The default exception is `\MPScholten\RequestParser\NotFoundException`.
-You can override the exception:
+When a parameter is required but not found or when validation fails, the library will throw an exception. The default exceptions are `\MPScholten\RequestParser\NotFoundException` and `\MPScholten\RequestParser\InvalidValueException`.
+You can customize the exceptions:
 
 ```php
+
+class FriendlyExceptionFactory extends \MPScholten\RequestParser\DefaultExceptionFactory
+{
+    protected function generateNotFoundMessage($parameterName)
+    {
+        return "Looks like $parameterName is missing :)";
+    }
+
+    protected function getNotFoundExceptionClass()
+    {
+        return CustomException::class;
+    }
+}
+
 class MyController
 {
     use \MPScholten\RequestParser\Symfony\ControllerHelperTrait;
     
     public function __construct(Request $request)
     {
-        $this->initRequestParser($request, function($parameter) {
-            throw new CustomException($message);
-        });
+        $this->initRequestParser($request, new FriendlyExceptionFactory());
     }
 }
 ```
+
+Check it out [this example about custom exceptions](https://github.com/mpscholten/request-parser/blob/master/examples/custom-exception.php).
 
 The suggested way to handle the errors thrown by the library is to catch them inside your front controller:
 
@@ -304,6 +318,8 @@ The suggested way to handle the errors thrown by the library is to catch them in
 try {
     $controller->$action();
 } catch (NotFoundException $e) {
+    echo $e->getMessage();
+} catch (InvalidValueException $e) {
     echo $e->getMessage();
 }
 ```

--- a/examples/custom-exception.php
+++ b/examples/custom-exception.php
@@ -13,16 +13,36 @@ class CustomException extends Exception
 
 }
 
+class FriendlyExceptionFactory extends \MPScholten\RequestParser\DefaultExceptionFactory
+{
+    protected function generateNotFoundMessage($parameterName)
+    {
+        return "Looks like $parameterName is missing :)";
+    }
+
+    protected function generateInvalidValueMessage($parameterName, $parameterValue, $expected)
+    {
+        return "Whoops :) $parameterName seems to be invalid. We're looking for $expected but you provided '$parameterValue'";
+    }
+
+    protected function getNotFoundExceptionClass()
+    {
+        return CustomException::class;
+    }
+
+    protected function getInvalidValueExceptionClass()
+    {
+        return CustomException::class;
+    }
+}
+
 class MyController
 {
     use ControllerHelperTrait;
 
     public function __construct(\Symfony\Component\HttpFoundation\Request $request)
     {
-        $customExceptionFactory = function($parameterName) {
-            throw new CustomException($parameterName);
-        };
-        $this->initRequestParser($request, $customExceptionFactory);
+        $this->initRequestParser($request, new FriendlyExceptionFactory());
     }
 
     public function hello()

--- a/src/AbstractValueParser.php
+++ b/src/AbstractValueParser.php
@@ -60,8 +60,5 @@ abstract class AbstractValueParser
         return $this->exceptionFactory->createInvalidValueException($this->name, $this->unparsedValue, $this->describe());
     }
 
-    protected function describe()
-    {
-        return "a value";
-    }
+    abstract protected function describe();
 }

--- a/src/BaseControllerHelperTrait.php
+++ b/src/BaseControllerHelperTrait.php
@@ -14,7 +14,7 @@ trait BaseControllerHelperTrait
      */
     private $bodyParser;
 
-    protected final function initRequestParser($request, callable $exceptionFactory = null)
+    protected final function initRequestParser($request, $exceptionFactory = null)
     {
         /** @var $requestParserFactory RequestParserFactory */
         $requestParserFactory = $this->createRequestParserFactory($request, $exceptionFactory);

--- a/src/BooleanParser.php
+++ b/src/BooleanParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class BooleanParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "either true or false";
+    }
+
     protected function parse($value)
     {
         if (strtoupper($value) === 'TRUE' || $value === '1') {

--- a/src/CommaSeparatedBooleanParser.php
+++ b/src/CommaSeparatedBooleanParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class CommaSeparatedBooleanParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a comma separated list of true or false";
+    }
+
     protected function parse($value)
     {
         $booleanArr = explode(',', $value);

--- a/src/CommaSeparatedDateTimeParser.php
+++ b/src/CommaSeparatedDateTimeParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class CommaSeparatedDateTimeParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a comma separated list of times";
+    }
+
     protected function parse($value)
     {
         $dateTimeArr = explode(',', $value);

--- a/src/CommaSeparatedFloatParser.php
+++ b/src/CommaSeparatedFloatParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class CommaSeparatedFloatParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a comma separated list of floating point numbers";
+    }
+
     protected function parse($value)
     {
         if (empty($value)) {

--- a/src/CommaSeparatedIntParser.php
+++ b/src/CommaSeparatedIntParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class CommaSeparatedIntParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a comma separated list of integers";
+    }
+
     protected function parse($value)
     {
         if (empty($value)) {

--- a/src/CommaSeparatedJsonParser.php
+++ b/src/CommaSeparatedJsonParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class CommaSeparatedJsonParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a comma separated list of json";
+    }
+
     protected function parse($value)
     {
         $value = '[' . $value . ']';

--- a/src/CommaSeparatedParser.php
+++ b/src/CommaSeparatedParser.php
@@ -8,7 +8,7 @@ class CommaSeparatedParser
     private $name;
     private $exceptionFactory;
 
-    public function __construct(callable $exceptionFactory, $name, $value)
+    public function __construct(ExceptionFactory $exceptionFactory, $name, $value)
     {
         $this->exceptionFactory = $exceptionFactory;
         $this->value = $value;

--- a/src/CommaSeparatedStringParser.php
+++ b/src/CommaSeparatedStringParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class CommaSeparatedStringParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a comma separated list of text";
+    }
+
     protected function parse($value)
     {
         return explode(',', $value);

--- a/src/CommaSeparatedYesNoBooleanParser.php
+++ b/src/CommaSeparatedYesNoBooleanParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class CommaSeparatedYesNoBooleanParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a comma separated list of yes or no";
+    }
+
     protected function parse($value)
     {
         $booleanArr = explode(',', $value);

--- a/src/DateTimeParser.php
+++ b/src/DateTimeParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class DateTimeParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a date or time";
+    }
+
     protected function parse($value)
     {
         if ($value === '') {

--- a/src/DefaultExceptionFactory.php
+++ b/src/DefaultExceptionFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace MPScholten\RequestParser;
+
+class DefaultExceptionFactory implements ExceptionFactory
+{
+    public function createNotFoundException($parameterName)
+    {
+        $class = $this->getNotFoundExceptionClass();
+        return new $class($this->generateNotFoundMessage($parameterName));
+    }
+
+    /**
+     * Override this method to customize the error message
+     */
+    protected function generateNotFoundMessage($parameterName)
+    {
+        return "Parameter \"$parameterName\" not found";
+    }
+
+    protected function getNotFoundExceptionClass()
+    {
+        return NotFoundException::class;
+    }
+
+    public function createInvalidValueException($parameterName, $parameterValue, $expected)
+    {
+        $class = $this->getInvalidValueExceptionClass();
+        return new $class($this->generateInvalidValueMessage($parameterName, $parameterValue, $expected));
+    }
+
+    /**
+     * Override this method to customize the error message
+     */
+    protected function generateInvalidValueMessage($parameterName, $parameterValue, $expected)
+    {
+        return "Invalid value for parameter \"$parameterName\". Expected $expected, but got \"$parameterValue\".";
+    }
+
+    protected function getInvalidValueExceptionClass()
+    {
+        return InvalidValueException::class;
+    }
+}

--- a/src/DefaultExceptionFactory.php
+++ b/src/DefaultExceptionFactory.php
@@ -4,6 +4,10 @@ namespace MPScholten\RequestParser;
 
 class DefaultExceptionFactory implements ExceptionFactory
 {
+    /**
+     * @param string $parameterName
+     * @return NotFoundException|\Exception
+     */
     public function createNotFoundException($parameterName)
     {
         $class = $this->getNotFoundExceptionClass();
@@ -23,6 +27,12 @@ class DefaultExceptionFactory implements ExceptionFactory
         return NotFoundException::class;
     }
 
+    /**
+     * @param string $parameterName
+     * @param string $parameterValue
+     * @param string $expected
+     * @return InvalidValueException|\Exception
+     */
     public function createInvalidValueException($parameterName, $parameterValue, $expected)
     {
         $class = $this->getInvalidValueExceptionClass();
@@ -34,7 +44,7 @@ class DefaultExceptionFactory implements ExceptionFactory
      */
     protected function generateInvalidValueMessage($parameterName, $parameterValue, $expected)
     {
-        return "Invalid value for parameter \"$parameterName\". Expected $expected, but got \"$parameterValue\".";
+        return "Invalid value for parameter \"$parameterName\". Expected $expected, but got \"$parameterValue\"";
     }
 
     protected function getInvalidValueExceptionClass()

--- a/src/DefaultExceptionFactory.php
+++ b/src/DefaultExceptionFactory.php
@@ -2,13 +2,34 @@
 
 namespace MPScholten\RequestParser;
 
+/**
+ * A flexible ExceptionFactory throwing the built-in `NotFoundException` and `InvalidValue` exceptions.
+ *
+ * To customize the error message: Override `generateNotFoundMessage` or `generateInvalidValueMessage`
+ * To customize the exception class: Override `getNotFoundExceptionClass` or `getInvalidValueExceptionClass`
+ *
+ * Example with custom error messages:
+ *
+ *      class FriendlyExceptionFactory extends DefaultExceptionFactory
+ *      {
+ *          protected function generateNotFoundMessage($parameterName)
+ *          {
+ *              return "$parameterName not found :)";
+ *          }
+ *
+ *          protected function generateInvalidValueMessage($parameterName, $parameterValue, $expected)
+ *          {
+ *              return "$parameterName is invalid :)";
+ *          }
+ *      }
+ */
 class DefaultExceptionFactory implements ExceptionFactory
 {
     /**
      * @param string $parameterName
      * @return NotFoundException|\Exception
      */
-    public function createNotFoundException($parameterName)
+    public final function createNotFoundException($parameterName)
     {
         $class = $this->getNotFoundExceptionClass();
         return new $class($this->generateNotFoundMessage($parameterName));
@@ -22,6 +43,10 @@ class DefaultExceptionFactory implements ExceptionFactory
         return "Parameter \"$parameterName\" not found";
     }
 
+    /**
+     * Override this method to customize the exception class
+     * @return string
+     */
     protected function getNotFoundExceptionClass()
     {
         return NotFoundException::class;
@@ -33,7 +58,7 @@ class DefaultExceptionFactory implements ExceptionFactory
      * @param string $expected
      * @return InvalidValueException|\Exception
      */
-    public function createInvalidValueException($parameterName, $parameterValue, $expected)
+    public final function createInvalidValueException($parameterName, $parameterValue, $expected)
     {
         $class = $this->getInvalidValueExceptionClass();
         return new $class($this->generateInvalidValueMessage($parameterName, $parameterValue, $expected));
@@ -47,6 +72,10 @@ class DefaultExceptionFactory implements ExceptionFactory
         return "Invalid value for parameter \"$parameterName\". Expected $expected, but got \"$parameterValue\"";
     }
 
+    /**
+     * Override this method to customize the exception class
+     * @return string
+     */
     protected function getInvalidValueExceptionClass()
     {
         return InvalidValueException::class;

--- a/src/ExceptionFactory.php
+++ b/src/ExceptionFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MPScholten\RequestParser;
+
+interface ExceptionFactory
+{
+    public function createNotFoundException($parameterName);
+    public function createInvalidValueException($parameterName, $parameterValue, $expected);
+}

--- a/src/ExceptionFactory.php
+++ b/src/ExceptionFactory.php
@@ -4,6 +4,29 @@ namespace MPScholten\RequestParser;
 
 interface ExceptionFactory
 {
+    /**
+     * Creates a new exception based on the parameter name which is thrown when the parameter
+     * is not found in the request.
+     *
+     * A possible implementation could be just:
+     *
+     *      return new Exception("$parameterName not found");
+     *
+     * @param string $parameterName
+     * @return \Exception
+     */
     public function createNotFoundException($parameterName);
+
+    /**
+     * Creates a new exception based on the parameter name, parameter value and a description
+     * of what is expected ("an integer", "either yes or no", "a string").
+     *
+     * A possible implementation could be just:
+     *
+     *      return new Exception("$parameterName was invalid. Got $parameterValue but expected $expected");
+     *
+     * @param string $parameterName
+     * @return \Exception
+     */
     public function createInvalidValueException($parameterName, $parameterValue, $expected);
 }

--- a/src/FloatParser.php
+++ b/src/FloatParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class FloatParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a floating point number";
+    }
+
     protected function parse($value)
     {
         return is_numeric($value) ? (float)$value : null;
@@ -25,10 +30,5 @@ class FloatParser extends AbstractValueParser
     public function required()
     {
         return parent::required();
-    }
-
-    protected function describe()
-    {
-        return "a valid floating point number";
     }
 }

--- a/src/FloatParser.php
+++ b/src/FloatParser.php
@@ -26,4 +26,9 @@ class FloatParser extends AbstractValueParser
     {
         return parent::required();
     }
+
+    protected function describe()
+    {
+        return "a valid floating point number";
+    }
 }

--- a/src/IntParser.php
+++ b/src/IntParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class IntParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "an integer";
+    }
+
     protected function parse($value)
     {
         return is_numeric($value) ? (int)$value : null;

--- a/src/InvalidValueException.php
+++ b/src/InvalidValueException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MPScholten\RequestParser;
+
+class InvalidValueException extends NotFoundException
+{
+}

--- a/src/JsonParser.php
+++ b/src/JsonParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class JsonParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a json encoded value";
+    }
+
     protected function parse($value)
     {
         return json_decode($value, true);

--- a/src/LegacyExceptionFactory.php
+++ b/src/LegacyExceptionFactory.php
@@ -4,12 +4,32 @@ namespace MPScholten\RequestParser;
 
 /**
  * TODO: Somehow tell the user that this is deprecated
+ *
+ * In a previous version of the library you could customize the error message with a simple closure like:
+ *
+ *      class MyController
+ *      {
+ *          use \MPScholten\RequestParser\Symfony\ControllerHelperTrait;
+ *
+ *          public function __construct(Request $request)
+ *          {
+ *              $this->initRequestParser($request, function($parameter) {
+ *                  throw new CustomException($message);
+ *              });
+ *          }
+ *      }
+ *
+ * This class transforms such a closure into a `ExceptionFactory` to keep b.c.
+ *
+ * For b.c. reasons invalid values are handled like not found values, so for
+ * an integer parameter with value "invalidInt" it just says "Parameter not found"
+ * instead of "Invalid value for integer".
  */
 class LegacyExceptionFactory implements ExceptionFactory
 {
     private $closure;
 
-    public function __construct($closure)
+    public function __construct(callable $closure)
     {
         $this->closure = $closure;
     }

--- a/src/LegacyExceptionFactory.php
+++ b/src/LegacyExceptionFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MPScholten\RequestParser;
+
+/**
+ * TODO: Somehow tell the user that this is deprecated
+ */
+class LegacyExceptionFactory implements ExceptionFactory
+{
+    private $closure;
+
+    public function __construct($closure)
+    {
+        $this->closure = $closure;
+    }
+
+    public function createNotFoundException($parameterName)
+    {
+        return call_user_func($this->closure, $parameterName);
+    }
+
+    public function createInvalidValueException($parameterName, $parameterValue, $expected)
+    {
+        return call_user_func($this->closure, $parameterName);
+    }
+}

--- a/src/OneOfParser.php
+++ b/src/OneOfParser.php
@@ -12,6 +12,11 @@ class OneOfParser extends AbstractValueParser
         parent::__construct($exceptionFactory, $name, $value);
     }
 
+    protected function describe()
+    {
+        return "one of " . implode(", ", $this->validValues);
+    }
+
     protected function parse($value)
     {
         if (in_array($value, $this->validValues)) {

--- a/src/OneOfParser.php
+++ b/src/OneOfParser.php
@@ -6,7 +6,7 @@ class OneOfParser extends AbstractValueParser
 {
     private $validValues;
 
-    public function __construct(callable $exceptionFactory, $name, $value, array $validValues)
+    public function __construct($exceptionFactory, $name, $value, array $validValues)
     {
         $this->validValues = $validValues;
         parent::__construct($exceptionFactory, $name, $value);

--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -13,9 +13,9 @@ class RequestParser
     public function __construct(callable $readParameter, $exceptionFactory = null)
     {
         if ($exceptionFactory === null) {
-            $exceptionFactory = function($parameter) {
-                return new NotFoundException("Parameter $parameter not found");
-            };
+            $exceptionFactory = new DefaultExceptionFactory();
+        } elseif (is_callable($exceptionFactory)) {
+            $exceptionFactory = new LegacyExceptionFactory($exceptionFactory);
         }
 
         $this->readParameter = $readParameter;

--- a/src/StringParser.php
+++ b/src/StringParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class StringParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "a text";
+    }
+
     protected function parse($value)
     {
         return (string) $value;

--- a/src/TypeParser.php
+++ b/src/TypeParser.php
@@ -8,7 +8,7 @@ class TypeParser
     private $name;
     private $exceptionFactory;
 
-    public function __construct(callable $exceptionFactory, $name, $value)
+    public function __construct(ExceptionFactory $exceptionFactory, $name, $value)
     {
         $this->exceptionFactory = $exceptionFactory;
         $this->value = $value;

--- a/src/YesNoBooleanParser.php
+++ b/src/YesNoBooleanParser.php
@@ -12,8 +12,15 @@ class YesNoBooleanParser extends AbstractValueParser
         if (strtoupper($value) === 'NO' || strtoupper($value) === 'N') {
             return false;
         }
+
         return null;
     }
+
+    protected function describe()
+    {
+        return "either YES or NO";
+    }
+
 
     /**
      * @param boolean $defaultValue

--- a/src/YesNoBooleanParser.php
+++ b/src/YesNoBooleanParser.php
@@ -4,6 +4,11 @@ namespace MPScholten\RequestParser;
 
 class YesNoBooleanParser extends AbstractValueParser
 {
+    protected function describe()
+    {
+        return "either yes or no";
+    }
+
     protected function parse($value)
     {
         if (strtoupper($value) === 'YES' || strtoupper($value) === 'Y') {
@@ -15,12 +20,6 @@ class YesNoBooleanParser extends AbstractValueParser
 
         return null;
     }
-
-    protected function describe()
-    {
-        return "either YES or NO";
-    }
-
 
     /**
      * @param boolean $defaultValue

--- a/tests/CommaSeparatedTypeParserTest.php
+++ b/tests/CommaSeparatedTypeParserTest.php
@@ -9,15 +9,14 @@ use MPScholten\RequestParser\CommaSeparatedIntParser;
 use MPScholten\RequestParser\CommaSeparatedJsonParser;
 use MPScholten\RequestParser\CommaSeparatedStringParser;
 use MPScholten\RequestParser\CommaSeparatedYesNoBooleanParser;
+use MPScholten\RequestParser\DefaultExceptionFactory;
 use MPScholten\RequestParser\NotFoundException;
 
 class CommaSeparatedTypeParserTest extends \PHPUnit_Framework_TestCase
 {
     private function createExceptionFactory()
     {
-        return function() {
-            throw new NotFoundException();
-        };
+        return new DefaultExceptionFactory();
     }
 
     public function testCsvWithInt()

--- a/tests/DefaultExceptionFactoryTest.php
+++ b/tests/DefaultExceptionFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use MPScholten\RequestParser\DefaultExceptionFactory;
+use MPScholten\RequestParser\NotFoundException;
+
+class DefaultExceptionFactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DefaultExceptionFactory
+     */
+    private $factory;
+
+    protected function setUp()
+    {
+        $this->factory = new DefaultExceptionFactory();
+    }
+
+    public function testCreateNotFoundException()
+    {
+        $exception = $this->factory->createNotFoundException('id');
+
+        $this->assertInstanceOf(NotFoundException::class, $exception);
+        $this->assertEquals('Parameter "id" not found', $exception->getMessage());
+    }
+
+    public function testCreateInvalidValueException()
+    {
+        $exception = $this->factory->createInvalidValueException('id', 'invalidinteger', 'an integer');
+
+        $this->assertInstanceOf(NotFoundException::class, $exception);
+        $this->assertEquals('Invalid value for parameter "id". Expected an integer, but got "invalidinteger"', $exception->getMessage());
+    }
+}

--- a/tests/Integration/Psr7IntegrationTest.php
+++ b/tests/Integration/Psr7IntegrationTest.php
@@ -46,7 +46,7 @@ class Psr7IntegrationTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotFoundActionThrowsException(Psr7Controller $controller)
     {
-        $this->setExpectedException(\MPScholten\RequestParser\NotFoundException::class, "Parameter notFound not found");
+        $this->setExpectedException(\MPScholten\RequestParser\NotFoundException::class, 'Parameter "notFound" not found');
         $controller->testNotFound();
     }
 }

--- a/tests/LegacyExceptionFactoryTest.php
+++ b/tests/LegacyExceptionFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use MPScholten\RequestParser\LegacyExceptionFactory;
+
+class LegacyExceptionFactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var LegacyExceptionFactory
+     */
+    private $factory;
+
+    protected function setUp()
+    {
+        $closure = function($parameterName) {
+            return new \Exception("not found: $parameterName");
+        };
+
+        $this->factory = new LegacyExceptionFactory($closure);
+    }
+
+    public function testCreateNotFoundException()
+    {
+        $exception = $this->factory->createNotFoundException('id');
+
+        $this->assertInstanceOf(\Exception::class, $exception);
+        $this->assertEquals('not found: id', $exception->getMessage());
+    }
+
+    public function testCreateInvalidValueException()
+    {
+        $exception = $this->factory->createInvalidValueException('id', 'invalidinteger', 'an integer');
+
+        $this->assertInstanceOf(\Exception::class, $exception);
+        $this->assertEquals('not found: id', $exception->getMessage());
+    }
+}

--- a/tests/ParserSpecTest.php
+++ b/tests/ParserSpecTest.php
@@ -5,6 +5,7 @@ use MPScholten\RequestParser\DateTimeParser;
 use MPScholten\RequestParser\DefaultExceptionFactory;
 use MPScholten\RequestParser\IntParser;
 use MPScholten\RequestParser\FloatParser;
+use MPScholten\RequestParser\InvalidValueException;
 use MPScholten\RequestParser\YesNoBooleanParser;
 use MPScholten\RequestParser\BooleanParser;
 use MPScholten\RequestParser\JsonParser;
@@ -54,8 +55,8 @@ class ParserSpecTest extends \PHPUnit_Framework_TestCase
         return [
             [new IntParser($this->createExceptionFactory(), 'id', 'string instead of an int'), 1],
             [new FloatParser($this->createExceptionFactory(), 'ration', 'string instead of an float'), 0.91],
-            [new YesNoBooleanParser($this->createExceptionFactory(), 'isAwesome', null), false],
-            [new BooleanParser($this->createExceptionFactory(), 'isAwesome', null), false],
+            [new YesNoBooleanParser($this->createExceptionFactory(), 'isAwesome', 'invalid'), false],
+            [new BooleanParser($this->createExceptionFactory(), 'isAwesome', 'invalid'), false],
             // StringParser has no invalid data types
             [new OneOfParser($this->createExceptionFactory(), 'type', 'x', ['a', 'b']), 'a'],
             [new DateTimeParser($this->createExceptionFactory(), 'createdAt', ''), new \DateTime('2015-01-01')],
@@ -109,7 +110,7 @@ class ParserSpecTest extends \PHPUnit_Framework_TestCase
      */
     public function testRequiredThrowsExceptionOnInvalidValue(AbstractValueParser $spec)
     {
-        $this->setExpectedException(NotFoundException::class);
+        $this->setExpectedException(InvalidValueException::class);
         $spec->required();
     }
 

--- a/tests/ParserSpecTest.php
+++ b/tests/ParserSpecTest.php
@@ -2,6 +2,7 @@
 
 use MPScholten\RequestParser\AbstractValueParser;
 use MPScholten\RequestParser\DateTimeParser;
+use MPScholten\RequestParser\DefaultExceptionFactory;
 use MPScholten\RequestParser\IntParser;
 use MPScholten\RequestParser\FloatParser;
 use MPScholten\RequestParser\YesNoBooleanParser;
@@ -15,9 +16,7 @@ class ParserSpecTest extends \PHPUnit_Framework_TestCase
 {
     private function createExceptionFactory()
     {
-        return function() {
-            throw new NotFoundException();
-        };
+        return new DefaultExceptionFactory();
     }
 
     public function specWithoutValueAndDefaultValueProvider()

--- a/tests/TypeSpecTest.php
+++ b/tests/TypeSpecTest.php
@@ -10,6 +10,7 @@ use MPScholten\RequestParser\CommaSeparatedJsonParser;
 use MPScholten\RequestParser\CommaSeparatedStringParser;
 use MPScholten\RequestParser\CommaSeparatedYesNoBooleanParser;
 use MPScholten\RequestParser\DateTimeParser;
+use MPScholten\RequestParser\DefaultExceptionFactory;
 use MPScholten\RequestParser\IntParser;
 use MPScholten\RequestParser\FloatParser;
 use MPScholten\RequestParser\YesNoBooleanParser;
@@ -24,9 +25,7 @@ class TypeSpecTest extends \PHPUnit_Framework_TestCase
 {
     private function createExceptionFactory()
     {
-        return function() {
-            throw new NotFoundException();
-        };
+        return new DefaultExceptionFactory();
     }
 
     public function testInt()


### PR DESCRIPTION
Implementation for #22.

This includes adding a new `ExceptionFactory` interface to provide an easy
way to customize exceptions. The standard implementation is
`DefaultExceptionFactory` and throws `NotFoundException` and `InvalidValueException`.

Also includes a `LegacyExceptionFactory` for support b.c. to the old closure
based exception configuration.

Open todos:
- [x] Implement `describe` for the remaining parsers
- [x] Fix failing tests
- [x] Add tests
- [x] Add some more doc blocks to the API methods with some examples
- [x] Refactor value handling to be more simple
- [x] Update documentation
- [x] Look for possible b.c. breaks and decide how to handle them
