### PR TITLE
Fixed `InvalidValueException` being thrown instead of `NotFoundException`

### DIFF
--- a/src/AbstractValueParser.php
+++ b/src/AbstractValueParser.php
@@ -55,7 +55,7 @@ abstract class AbstractValueParser
                 $notFoundMessage = $this->config->getExceptionMessageFactory()->createNotFoundMessage($this->name);
             }
 
-            throw $this->config->getExceptionFactory()->createInvalidValueException($notFoundMessage);
+            throw $this->config->getExceptionFactory()->createNotFoundException($notFoundMessage);
         }
 
         return $this->value;


### PR DESCRIPTION
@yuvalherziger could you review this? @fredpe just found this bug